### PR TITLE
Issue #22 : Fix for "HTTPHeaders object is not JSON serializable"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado >= 3.1
+tornado <=4.2, >=3.1
 markdown2 >= 2.1.0
 py-bcrypt >= 0.3
 futures >= 2.1.3


### PR DESCRIPTION
Workaround for tornado's Header can not be json-serialized.
Just give a specified version of tornado to avoid this problem.

More job will be done in another ticket maybe:)